### PR TITLE
Sort order bugfix

### DIFF
--- a/behaviors/Fetch_FetchedElementsBehavior.php
+++ b/behaviors/Fetch_FetchedElementsBehavior.php
@@ -13,6 +13,7 @@ namespace Craft;
 class Fetch_FetchedElementsBehavior extends BaseBehavior
 {
 	protected $_elementsByFieldHandle = array();
+	protected $_sortOrdersByFieldHandle = array();
 
 	/**
 	 * Returns an array of pre-fetched related elements, optionally restricted by one or more
@@ -74,7 +75,11 @@ class Fetch_FetchedElementsBehavior extends BaseBehavior
 			$this->_elementsByFieldHandle[$fieldHandle] = array();
 		}
 
-		$this->_elementsByFieldHandle[$fieldHandle][$sortOrder] = $element;
+		$this->_elementsByFieldHandle[$fieldHandle][] = $element;
+		$this->_sortOrdersByFieldHandle[$fieldHandle][] = $sortOrder;
+
+		// Keep the elements sorted based on the sort order
+		array_multisort($this->_sortOrdersByFieldHandle[$fieldHandle], $this->_elementsByFieldHandle[$fieldHandle]);
 
 		return true;
 	}


### PR DESCRIPTION
If two related elements with the same sort order were eager-loaded for the same source element, one would overwrite the other. This commit fixes that.
