### PR TITLE
Check to see if behavior is already attached to element

### DIFF
--- a/services/FetchService.php
+++ b/services/FetchService.php
@@ -45,7 +45,10 @@ class FetchService extends BaseApplicationComponent
 		// Attach the behavior to each of the source elements
 		foreach($sourceElementsById as $sourceElement)
 		{
-			$sourceElement->attachBehavior('fetched_elements', new Fetch_FetchedElementsBehavior());
+			// Make sure the behavior hasn't already been attached
+			if (!$sourceElement->asa('fetched_elements')) {
+				$sourceElement->attachBehavior('fetched_elements', new Fetch_FetchedElementsBehavior());
+			}
 		}
 
 		// Perform the first query to get the information from the craft_relations table


### PR DESCRIPTION
I added a check to see if the behavior is already attached to the element. This allows you to use the fetch service multiple times on the same source elements.

Consider the following scenario.

```
$elements = craft()->fetch->elements('Asset', $elements, ['images']);
$elements = craft()->fetch->elements('Category', $elements, ['categories']);

Craft::dd($elements[0]->fetch('images'));
```

In the code above, related Asset elements are fetched and attached to the source elements. Then the source elements with the attached `fetched_elements` are passed to the fetch service to retrieve related categories. However, a new `fetched_elements` behavior will be attached again, losing the previously fetched images. This results in `$elements[0]->fetch('images')` returning null instead of the expected AssetFileModels collection.
